### PR TITLE
🐛 Use the `today` prop in `isFutureDate`/`isPastDate` calculations

### DIFF
--- a/src/datepicker.svelte
+++ b/src/datepicker.svelte
@@ -673,7 +673,7 @@
     }
 
     const selectedDateTimestamp = createTimestamp(year, month, day);
-    const todayCompare = normalizeTimestamp(new Date());
+    const todayCompare = normalizeTimestamp(today);
     const selectedCompare = normalizeTimestamp(selectedDateTimestamp);
 
     return todayCompare < selectedCompare;
@@ -693,7 +693,7 @@
     }
 
     const selectedDateTimestamp = createTimestamp(year, month, day);
-    const todayCompare = normalizeTimestamp(new Date());
+    const todayCompare = normalizeTimestamp(today);
     const selectedCompare = normalizeTimestamp(selectedDateTimestamp);
 
     return todayCompare > selectedCompare;


### PR DESCRIPTION
**Why these changes?**

Today is not the same everywhere around the world - (unfortunately) timezones exist :D 

This change allows you to pass the `today` object as a prop, and makes the isPast/isFuture function depend on it 

**How do we test?**

Pass an arbitrary `today` value - it should effect the disabled dates in the datepicker

